### PR TITLE
Also publish to gh npm packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,23 @@ jobs:
     needs: [static-checks-npm, tests-npm]
     uses: digicatapult/shared-workflows/.github/workflows/release-module-npm.yml@main
     with:
-      npm_build: true
+      npm_build_command: npm run build
     permissions:
       contents: write
+      packages: write
     secrets:
       REGISTRY_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}
+  release-gh-packages:
+    needs: [static-checks-npm, tests-npm]
+    uses: digicatapult/shared-workflows/.github/workflows/release-module-npm.yml@main
+    with:
+      npm_build_command: npm run build 
+      registry_url: 'https://npm.pkg.github.com'
+    permissions:
+      contents: write
+      packages: write
   release-github:
-    needs: [release-npm]
+    needs: [release-npm, release-gh-packages]
     uses: digicatapult/shared-workflows/.github/workflows/release-github.yml@main
     permissions:
       contents: write

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/tsoa-oauth-express",
-  "version": "0.1.84",
+  "version": "0.1.85",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/tsoa-oauth-express",
-      "version": "0.1.84",
+      "version": "0.1.85",
       "license": "Apache-2.0",
       "dependencies": {
         "jsonwebtoken": "^9.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/tsoa-oauth-express",
-  "version": "0.1.84",
+  "version": "0.1.85",
   "description": "Authentication handler for TSOA using OAuth2 JWT tokens",
   "main": "build/index.js",
   "type": "commonjs",


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [ ] Bug Fix
- [x] Chore
- [ ] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

Related to https://digicatapult.atlassian.net/browse/SQNC-50

## High level description

Publish to gh npm packages as well as npm

## Detailed description

Because https://github.com/digicatapult/sqnc-process-management published packages to both npm and github packages I've had to implement https://github.com/digicatapult/shared-workflows/pull/18 so that we can publish to github. As this was a breaking change I'm updating here as well as part of that fix. As an aside this enables us to publish this package to github as well.

## Describe alternatives you've considered

Could have just updated the permissions as the minimum. This doesn't really cost anything though and provides another registry option.

## Operational impact

See https://github.com/digicatapult/shared-workflows/pull/18 for rollback steps

## Additional context

https://github.com/digicatapult/shared-workflows/pull/18
